### PR TITLE
[68] Using a different API for geocoding

### DIFF
--- a/app/src/main/java/com/avans/rentmycar/adapter/OfferAdapter.kt
+++ b/app/src/main/java/com/avans/rentmycar/adapter/OfferAdapter.kt
@@ -59,6 +59,8 @@ class OfferAdapter(
             offerEndDate.text = itemView.context.getString(R.string.offer_returnBefore, endDate)
             offerLocation.text = offerData.pickupLocation
 
+            Log.d("[OAdapt] distance", "distance: " + offerData.distance)
+
             if (offerData.distance < 1000) { // If the distance < 1000, show the distance in meters
                 offerDistance.text = offerData.distance.toInt().toString() + "m"
             } else if (offerData.distance > 1000) { // If the distance > 1000, show the distance in kilometers

--- a/app/src/main/java/com/avans/rentmycar/api/MapsApiService.kt
+++ b/app/src/main/java/com/avans/rentmycar/api/MapsApiService.kt
@@ -1,24 +1,41 @@
 package com.avans.rentmycar.api
 
 import com.avans.rentmycar.BuildConfig.MAPS_API_KEY
-import com.avans.rentmycar.model.GeocodeResponse
+import com.avans.rentmycar.BuildConfig.POSITIONSTACK_API_KEY
+import com.avans.rentmycar.model.GeocodeResponseGoogle
+import com.avans.rentmycar.model.GeocodeResponsePositionstack
 import com.avans.rentmycar.rest.ApiClient
+import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 
 interface MapsApiService {
 
-    @GET("https://maps.googleapis.com/maps/api/geocode/json")
+
+
+    @GET("http://api.positionstack.com/v1/forward")
     suspend fun getLatLongFromAddress(
+        @Query("query") pickupLocation: String,
+        @Query("access_key") key: String = POSITIONSTACK_API_KEY
+    ): GeocodeResponsePositionstack
+
+
+    @GET("https://maps.googleapis.com/maps/api/geocode/json")
+    suspend fun getLatLongFromAddressGoogle(
         @Query("address") pickupLocation: String,
         @Query("key") key: String = MAPS_API_KEY
-    ): GeocodeResponse
+    ): GeocodeResponseGoogle
 
     companion object {
         fun getApi(): MapsApiService? {
             return ApiClient.client?.create(MapsApiService::class.java)
         }
+
+        val interceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
     }
 
 }

--- a/app/src/main/java/com/avans/rentmycar/model/GeocodeResponseGoogle.kt
+++ b/app/src/main/java/com/avans/rentmycar/model/GeocodeResponseGoogle.kt
@@ -2,7 +2,7 @@ package com.avans.rentmycar.model
 
 import com.squareup.moshi.Json
 
-data class GeocodeResponse(
+data class GeocodeResponseGoogle(
 
 	@Json(name="results")
 	val results: List<ResultsItem?>? = null,

--- a/app/src/main/java/com/avans/rentmycar/model/GeocodeResponsePositionstack.kt
+++ b/app/src/main/java/com/avans/rentmycar/model/GeocodeResponsePositionstack.kt
@@ -1,0 +1,66 @@
+package com.avans.rentmycar.model
+
+import com.squareup.moshi.Json
+
+data class GeocodeResponsePositionstack(
+
+	@Json(name="data")
+	val data: List<DataItem?>? = null
+)
+
+data class DataItem(
+
+	@Json(name="continent")
+	val continent: String? = null,
+
+	@Json(name="country")
+	val country: String? = null,
+
+	@Json(name="latitude")
+	val latitude: Double? = 0.0,
+
+	@Json(name="confidence")
+	val confidence: Int? = null,
+
+	@Json(name="county")
+	val county: String? = null,
+
+	@Json(name="locality")
+	val locality: String? = null,
+
+	@Json(name="administrative_area")
+	val administrativeArea: Any? = null,
+
+	@Json(name="label")
+	val label: String? = null,
+
+	@Json(name="type")
+	val type: String? = null,
+
+	@Json(name="number")
+	val number: String? = null,
+
+	@Json(name="country_code")
+	val countryCode: String? = null,
+
+	@Json(name="street")
+	val street: String? = null,
+
+	@Json(name="neighbourhood")
+	val neighbourhood: String? = null,
+
+	@Json(name="name")
+	val name: String? = null,
+
+	@Json(name="postal_code")
+	val postalCode: String? = null,
+
+	@Json(name="region")
+	val region: String? = null,
+
+	@Json(name="longitude")
+	val longitude: Double? = 0.0,
+
+	@Json(name="region_code")
+	val regionCode: String? = null
+)

--- a/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
+++ b/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
@@ -62,8 +62,8 @@ class HomeDetailFragment : Fragment() {
         viewModel.geocodeResult?.observe(viewLifecycleOwner) {
             val geocodeResponse = viewModel.geocodeResult!!.value
             if (geocodeResponse != null) {
-                offerLat = geocodeResponse.results?.get(0)?.geometry?.location?.lat!!
-                offerLng = geocodeResponse.results.get(0)?.geometry?.location?.lng!!
+                offerLat = geocodeResponse.data?.get(0)?.latitude!!
+                offerLng = geocodeResponse.data?.get(0)?.longitude!!
             }
 
             if (mapFragment.isAdded) {

--- a/app/src/main/java/com/avans/rentmycar/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/avans/rentmycar/ui/home/HomeFragment.kt
@@ -83,7 +83,7 @@ class HomeFragment : Fragment() {
 
         val model = ViewModelProvider(requireActivity())[OfferViewModel::class.java]
         model.offerCollection.observe(viewLifecycleOwner) {
-
+        Log.d("[Home] model.offerColl", it.toString())
             offerAdapter.setData(it)
             if (it.isEmpty()) {
                 Log.d("[Home]", "No offers found")

--- a/app/src/main/java/com/avans/rentmycar/viewmodel/OfferViewModel.kt
+++ b/app/src/main/java/com/avans/rentmycar/viewmodel/OfferViewModel.kt
@@ -6,10 +6,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.avans.rentmycar.api.MapsApiService
-import com.avans.rentmycar.model.BookingData
-import com.avans.rentmycar.model.CreateBookingResponse
-import com.avans.rentmycar.model.GeocodeResponse
-import com.avans.rentmycar.model.OfferData
+import com.avans.rentmycar.model.*
 import com.avans.rentmycar.repository.OfferRepository
 import com.avans.rentmycar.utils.SessionManager
 import com.google.android.gms.maps.model.LatLng
@@ -23,7 +20,7 @@ class OfferViewModel : ViewModel() {
     // TODO: Refactor this
     val bookingsResult: MutableLiveData<Collection<BookingData>> = MutableLiveData()
     val createBookingResult: MutableLiveData<CreateBookingResponse?> = MutableLiveData()
-    var geocodeResult: MutableLiveData<GeocodeResponse?>? = MutableLiveData()
+    var geocodeResult: MutableLiveData<GeocodeResponsePositionstack?>? = MutableLiveData()
 
 
     // ===== Variables for the API calls =====
@@ -67,20 +64,41 @@ class OfferViewModel : ViewModel() {
     // ===== Offers =====
     fun setOfferCollection(offers: Collection<OfferData>) {
 
+        Log.d("[OVM] setOffColl", "setOfferCollection: $offers")
+
+        Log.d("[OVM] setOffColl", "setOfferCollection numberOfSeatsFilter.value: ${numberOfSeatsFilter.value}")
+        Log.d("[OVM] setOffColl", "setOfferCollection maxDistanceInKmFilter.value: ${maxDistanceInKmFilter.value}")
+
         var filteredOffers = offers.filter { it.car.numberOfSeats >= numberOfSeatsFilter.value!! }
-        filteredOffers = filteredOffers.filter { it.distance <= (maxDistanceInKmFilter.value!! * 1000) }
+                Log.d("[OVM] setOffColl", "setOfferCollection filteredOffers na seats: $filteredOffers")
+
+//        filteredOffers = filteredOffers.filter { it.distance <= (maxDistanceInKmFilter.value!! * 1000) }
+//        Log.d("[OVM] setOffColl", "setOfferCollection filteredOffers na distance: $filteredOffers")
+
+
 
         if (!checkboxFuelTypeIceFilter.value!!) {
             filteredOffers = filteredOffers.filter { it.car.type != "ICE" }
         }
 
+        Log.d("[OVM] setOffColl", "setOfferCollection filteredOffers na ICE check: $filteredOffers")
+
+
         if (!checkboxFuelTypeBevFilter.value!!) {
             filteredOffers = filteredOffers.filter { it.car.type != "BEV" }
         }
 
+        Log.d("[OVM] setOffColl", "setOfferCollection filteredOffers na BEV check: $filteredOffers")
+
+
         if (!checkboxFuelTypeFcevFilter.value!!) {
             filteredOffers = filteredOffers.filter { it.car.type != "FCEV" }
         }
+
+        Log.d("[OVM] setOffColl", "setOfferCollection filteredOffers na FCEV check: $filteredOffers")
+
+
+        Log.d("[OVM] setOffColl", "setOfferCollection: filteredOffers: $filteredOffers")
 
         offerCollection.value = filteredOffers
     }
@@ -95,13 +113,19 @@ class OfferViewModel : ViewModel() {
 
     // ===== Repository Interaction =====
     fun getOffers() {
+        Log.d("[OVM] getOffers", "getOffers called")
         viewModelScope.launch {
             try {
                 val offerResponse = offerRepository.getOpenOffers()
+                Log.d("[OVM] getOffers", "offerResponse: $offerResponse")
 
                 if(SessionManager.getLocationPermissionGranted()) {
+                    Log.d("[OVM] getOffers", "Location permission granted. Show offers with distances.")
                     setOfferCollection(updateOfferDataWithDistance(offerResponse))
+//                    setOfferCollection(offerResponse) // TODO: Remove this line when distance is implemented correctly again
+
                 } else {
+                    Log.d("[OVM] getOffers", "Location permission not granted. Show offers without distances.")
                     setOfferCollection(offerResponse)
                 }
 
@@ -119,17 +143,40 @@ class OfferViewModel : ViewModel() {
         deviceLocation.latitude = userLocation.latitude
         deviceLocation.longitude = userLocation.longitude
         offers.forEach { offer ->
+
+            Log.d("[OVM] uOfferWithDist", "offer: $offer")
+
             val pickupLocation = offer.pickupLocation
-            val pickupLocationGeocode = MapsApiService.getApi()
-                ?.getLatLongFromAddress(pickupLocation)?.results?.get(0)?.geometry?.location
-            val pickupLocationLatLng =
-                LatLng(pickupLocationGeocode?.lat!!, pickupLocationGeocode.lng!!)
+            Log.d("[OVM] uOfferWithDist", "pickupLocation: $pickupLocation")
+            val pickupGeolocationResponse = MapsApiService.getApi()
+                ?.getLatLongFromAddress(pickupLocation)?.data?.get(0)
+            Log.d("[OVM] uOfferWithDist", "pickupGeolocationResponse: $pickupGeolocationResponse")
+
+            val pickupLocationLatLng = pickupGeolocationResponse?.let {
+                it.latitude?.let { it1 -> it.longitude?.let { it2 -> LatLng(it1, it2) } }
+            }
+//            Log.d("[OVM] uOfferWithDist", "pickupLocationLatLng: $pickupLocationLatLng")
+
             val pickupLocationLocation = Location("pickupLocation")
-            pickupLocationLocation.latitude = pickupLocationLatLng.latitude
-            pickupLocationLocation.longitude = pickupLocationLatLng.longitude
+
+            Log.d("[OVM] uOfferWithDist", "pickupLocationLocation: $pickupLocationLocation")
+
+            if (pickupLocationLatLng != null) {
+                pickupLocationLocation.latitude = pickupLocationLatLng.latitude
+            }
+            if (pickupLocationLatLng != null) {
+                pickupLocationLocation.longitude = pickupLocationLatLng.longitude
+            }
+
+            Log.d("[OVM] uOfferWithDist", "pickupLocationLocation 2: $pickupLocationLocation")
+
+
             val distance = deviceLocation.distanceTo(pickupLocationLocation)
+            Log.d("[OVM] uOfferWithDist", "distance: $distance")
             offer.distance = distance
         }
+
+        Log.d("[OVM] uOfferWithDist", "offers after everything: $offers")
 
         return offers.sortedBy { offer -> offer.distance }
     }
@@ -146,11 +193,23 @@ class OfferViewModel : ViewModel() {
                 deviceLocation.longitude = userLocation.longitude
                 getBookingResponse.forEach { booking ->
                     val pickupLocation = booking.offer.pickupLocation
-                    val pickupLocationGeocode = MapsApiService.getApi()?.getLatLongFromAddress(pickupLocation)?.results?.get(0)?.geometry?.location
-                    val pickupLocationLatLng = LatLng(pickupLocationGeocode?.lat!!, pickupLocationGeocode.lng!!)
+                    val pickupLocationLatLng =
+                        MapsApiService.getApi()
+                            ?.getLatLongFromAddress(pickupLocation)?.data?.get(0)?.latitude?.let {
+                                MapsApiService.getApi()
+                                    ?.getLatLongFromAddress(pickupLocation)?.data?.get(0)?.longitude?.let { it1 ->
+                                        LatLng(
+                                            it, it1
+                                        )
+                                    }
+                            }
                     val pickupLocationLocation = Location("pickupLocation")
-                    pickupLocationLocation.latitude = pickupLocationLatLng.latitude
-                    pickupLocationLocation.longitude = pickupLocationLatLng.longitude
+                    if (pickupLocationLatLng != null) {
+                        pickupLocationLocation.latitude = pickupLocationLatLng.latitude
+                    }
+                    if (pickupLocationLatLng != null) {
+                        pickupLocationLocation.longitude = pickupLocationLatLng.longitude
+                    }
                     val distance = deviceLocation.distanceTo(pickupLocationLocation)
                     booking.offer.distance = distance
                 }
@@ -183,6 +242,7 @@ class OfferViewModel : ViewModel() {
         viewModelScope.launch {
             try {
                 val geocodeResponse = MapsApiService.getApi()?.getLatLongFromAddress(pickupLocation)
+                Log.i("[OfferVM] geocodeResp", geocodeResponse.toString())
                 geocodeResult?.value = geocodeResponse
             } catch (e: Exception) {
                 Log.e("[OfferVM] getGeoRespon", e.message.toString())


### PR DESCRIPTION
Een andere API genomen voor de geocoding als snelle fix.

De permanentere fix wordt de locatiedata opvragen bij het maken van een offer en deze meteen meegeven in de database. Dat is een nieuwe issue-card.