### PR TITLE
96 when viewing an offer of my own car i should not see a book button

### DIFF
--- a/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
+++ b/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
@@ -61,6 +61,11 @@ class HomeDetailFragment : Fragment() {
                     Glide.with(this).load(offer.car.image).into(it)
                 }
 
+                if(offer.car.user.id == SessionManager.getUserId(requireContext())) {
+                    binding.buttonHomeDetailBook.isEnabled = false
+                    binding.buttonHomeDetailBook.text = getString(R.string.cannot_book_own_car)
+                }
+
                 actionBar?.title = offer.car.model
 
                 if (mapFragment.isAdded) {
@@ -69,6 +74,8 @@ class HomeDetailFragment : Fragment() {
 
             }
         }
+
+
 
         // Setup Book Button
         binding.buttonHomeDetailBook.setOnClickListener {

--- a/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
+++ b/app/src/main/java/com/avans/rentmycar/ui/home/HomeDetailFragment.kt
@@ -64,6 +64,7 @@ class HomeDetailFragment : Fragment() {
                 if(offer.car.user.id == SessionManager.getUserId(requireContext())) {
                     binding.buttonHomeDetailBook.isEnabled = false
                     binding.buttonHomeDetailBook.text = getString(R.string.cannot_book_own_car)
+                    binding.buttonHomeDetailBook.setBackgroundColor(resources.getColor(R.color.gray))
                 }
 
                 actionBar?.title = offer.car.model

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -77,4 +77,5 @@
     <string name="booking_cancel_dialog_button_positive">Ja, verwijderen</string>
 
     <string name="_1s_kilometer_driven">%1$s gereden kilometers</string>
+    <string name="cannot_book_own_car">Je kunt je eigen auto niet boeken</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,4 +79,5 @@
     <string name="booking_cancel_dialog_button_negative">No, keep it</string>
     <string name="booking_cancel_dialog_button_positive">Yes, continue cancel</string>
     <string name="_1s_kilometer_driven">%1$s kilometer driven</string>
+    <string name="cannot_book_own_car">Can not book your own car</string>
 </resources>


### PR DESCRIPTION
- Wanneer je de offer van een eigen auto bekijkt, is de knop om de Offer de boeken nu niet beschikbaar meer. De tekst en aangepaste kleur geven aan waarom deze boeking niet mogelijk is. Dat leek me achteraf betere informatie voor de gebruiker dan de knop niet te tonen.
![image](https://user-images.githubusercontent.com/83649301/212650099-ba55c04b-118a-4bcf-9e93-b3d03a0e75bd.png)
