### PR TITLE
[119] Toast gets displayed when registering is unsuccessful

### DIFF
--- a/app/src/main/java/com/avans/rentmycar/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/com/avans/rentmycar/viewmodel/LoginViewModel.kt
@@ -68,7 +68,7 @@ class LoginViewModel(application: Application) : AndroidViewModel(application) {
                 } else {
                     Log.d("APP", "not working this")
 
-                    loginResult.value = BaseResponse.Error(response?.message())
+                    registerResult.value = BaseResponse.Error(response?.message())
                 }
 
             } catch (ex: Exception) {


### PR DESCRIPTION
Ik heb een `loginResult.value` veranderd in `registerResult.value` en nu toont er netjes een toast en verdwijnt de loader die genoemd is in de issue.

![image](https://user-images.githubusercontent.com/83649301/213998799-76d94f31-020e-49a7-8979-bb95e96dbf74.png)


Een upgrade kan nog worden dat de gebruiker de melding krijgt waarom het aanmelden mislukt (in dit geval een bestaand emailadres). Dat is echter niet de bug van deze kaart, dus deze kaart is bij deze afgerond 💪 